### PR TITLE
Migrating from React.PropTypes to PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "git-url-parse": "^6.0.1",
     "jsdom": "^8.3.1",
     "mocha": "^2.4.5",
+    "prop-types": "^15.0.0",
     "raw-loader": "^0.5.1",
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@
  *
  */
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import { iframeResizer as iframeResizerLib } from 'iframe-resizer';
 
@@ -112,26 +113,26 @@ class IframeResizer extends React.Component {
 IframeResizer.propTypes = {
   // iframe content/document
   // option 1. content of HTML to load in the iframe
-  content: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.element,
+  content: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element,
   ]),
   // option 2. src to a URL to load in the iframe
-  src: React.PropTypes.string,
+  src: PropTypes.string,
   // iframe-resizer controls and helpers
-  iframeResizerEnable: React.PropTypes.bool,
-  iframeResizerOptions: React.PropTypes.object,
-  iframeResizerUrl: React.PropTypes.oneOfType([
-    React.PropTypes.string, // URL to inject
-    React.PropTypes.bool, // false = disable inject
+  iframeResizerEnable: PropTypes.bool,
+  iframeResizerOptions: PropTypes.object,
+  iframeResizerUrl: PropTypes.oneOfType([
+    PropTypes.string, // URL to inject
+    PropTypes.bool, // false = disable inject
   ]),
   // misc props to pass through to iframe
-  id: React.PropTypes.string,
-  frameBorder: React.PropTypes.number,
-  className: React.PropTypes.string,
-  style: React.PropTypes.object,
+  id: PropTypes.string,
+  frameBorder: PropTypes.number,
+  className: PropTypes.string,
+  style: PropTypes.object,
   // optional extra callback when iframe is loaded
-  // onIframeLoaded: React.PropTypes.func,
+  // onIframeLoaded: PropTypes.func,
 };
 IframeResizer.defaultProps = {
   // resize iframe


### PR DESCRIPTION
`React.PropType` will be deprecated in future releases in favor of `prop-types` package.

From React's website:

> Prop types are a feature for runtime validation of props during development. We've extracted the built-in prop types to a separate package to reflect the fact that not everybody uses them.
> 
> In 15.5, instead of accessing PropTypes from the main React object, install the prop-types package and import them from there

More info at [this link](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes)