### PR TITLE
Fix iframe-resizer "not found" warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "style-loader": "^0.13.1"
   },
   "peerDependencies": {
-    "iframe-resizer": "^3.5.8",
+    "iframe-resizer": "^3.6.2",
     "react": "^0.14.7 || ^15.0.0"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,12 @@ class IframeResizer extends React.Component {
     this.updateIframe(this.props);
     this.resizeIframe(this.props);
   }
+  componentWillUnmount() {
+    // React will remove the iframe, however we need to manually
+    // call iframe-resizer to stop its listeners
+    iframeResizer = this.refs.frame.iFrameResizer
+    iframeResizer && iframeResizer.removeListeners();
+  }
   componentWillReceiveProps(nextProps) {
     // can replace content if we got new props
     this.updateIframe(nextProps);


### PR DESCRIPTION
Fixes `iframe not found` warnings described in: https://github.com/davidjbradshaw/iframe-resizer/pull/626