### PR TITLE
Use iframeProps to pass through misc props to iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ const MyComponent = props => (
 - `iframeResizerUrl` (string || bool) URL to the client JS for injecting into the
   iframe.  This only works for `content` type, at the moment.  The default URL
   is `https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.8/iframeResizer.contentWindow.min.js`. If you wanted to disable this, you could set it to {false}
-- `frameBorder` (number) [0] optionally set a frameBorder
-- `id` (string) optionally set an id property
-- `className` (string) optionally set a className property
-- `style` (object) optionally set a style property
-  default `{ width: '100%', minHeight: 20 }`
+- `iframeProps` (object) will be directly passed to the iframe
+- ~~`frameBorder` (number) [0] optionally set a frameBorder~~
+- ~~`id` (string) optionally set an id property~~
+- ~~`className` (string) optionally set a className property~~
+- ~~`style` (object) optionally set a style property
+  default `{ width: '100%', minHeight: 20 }`~~
 
 ## Examples
 

--- a/src/index.js
+++ b/src/index.js
@@ -102,9 +102,23 @@ class IframeResizer extends React.Component {
     }
   }
   render() {
-    const { src, id, frameBorder, className, style } = this.props;
+    const {
+      src,
+      id: legacyId,
+      frameBorder: legacyFrameBorder,
+      className: legacyClassName,
+      style: legacyStyle,
+      iframeProps: {
+        id = legacyId,
+        frameBorder = legacyFrameBorder,
+        className = legacyClassName,
+        style = legacyStyle,
+        ...iframeProps
+      }
+    } = this.props;
     return (
       <iframe
+        {...iframeProps}
         ref="frame"
         src={src}
         id={id}
@@ -132,13 +146,22 @@ IframeResizer.propTypes = {
     PropTypes.string, // URL to inject
     PropTypes.bool, // false = disable inject
   ]),
-  // misc props to pass through to iframe
+  // backward compatible misc props to pass through to iframe
   id: PropTypes.string,
   frameBorder: PropTypes.number,
   className: PropTypes.string,
   style: PropTypes.object,
   // optional extra callback when iframe is loaded
   // onIframeLoaded: PropTypes.func,
+  // misc props to pass through to iframe
+  iframeProps: PropTypes.shape({
+    className: PropTypes.string,
+    frameBorder: PropTypes.number,
+    id: PropTypes.string,
+    sandbox: PropTypes.string,
+    style: PropTypes.object,
+    title: PropTypes.string
+  })
 };
 IframeResizer.defaultProps = {
   // resize iframe

--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,7 @@ class IframeResizer extends React.Component {
         className = legacyClassName,
         style = legacyStyle,
         ...iframeProps
-      }
+      } = {}
     } = this.props;
     return (
       <iframe


### PR DESCRIPTION
There are a number of misc props of iframe that might be useful to some so instead of explicitly declaring each one just provide a way to specify any.

I added a backward compatible fallback so existing misc props are still working and could be removed at a feature time.