### PR TITLE
Upgrade to iframe-resizer 4.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "style-loader": "^0.13.1"
   },
   "peerDependencies": {
-    "iframe-resizer": "^3.6.2",
+    "iframe-resizer": "^4.2.3",
     "react": "^0.14.7 || ^15.0.0 || ^16.0"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -149,10 +149,10 @@ IframeResizer.defaultProps = {
     // checkOrigin: false,
     // resizeFrom: 'parent',
     // heightCalculationMethod: 'max',
-    // initCallback: () => { console.log('ready!'); },
-    // resizedCallback: () => { console.log('resized!'); },
+    // onInit: () => { console.log('ready!'); },
+    // onResized: () => { console.log('resized!'); },
   },
-  iframeResizerUrl: 'https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.8/iframeResizer.contentWindow.min.js',
+  iframeResizerUrl: 'https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.2.1/iframeResizer.contentWindow.min.js',
   // misc props to pass through to iframe
   frameBorder: 0,
   style: {


### PR DESCRIPTION
**Breaking change:** 

* iframe-resizer v4.0.0 - Drop support for IE8-10 and Andriod 4
* iframe-resizer v4.0.0 - Rename event handlers from `fooCallback` to `onFoo`

[full changelog](https://github.com/davidjbradshaw/iframe-resizer/blob/master/CHANGELOG.md)

Note: v4.2.1 is the latest available version on cdn